### PR TITLE
Fixed problem with nested HTML inside the anchor

### DIFF
--- a/src/anchor-link.js
+++ b/src/anchor-link.js
@@ -14,7 +14,7 @@ class AnchorLink extends Component {
     if (typeof this.props.offset !== 'undefined') {
       offset = parseInt(this.props.offset)
     }
-    const id = e.target.getAttribute('href').slice(1)
+    const id = e.currentTarget.getAttribute('href').slice(1)
     window.scroll({
       top: document.getElementById(`${id}`).offsetTop - offset,
       behavior: 'smooth'


### PR DESCRIPTION
"currentTarget" always selects the `a` tag so one can nest HTML inside the link.