### PR TITLE
Prevent undefined exception on missing ID

### DIFF
--- a/src/anchor-link.js
+++ b/src/anchor-link.js
@@ -20,11 +20,15 @@ class AnchorLink extends Component {
     }
     const id = e.currentTarget.getAttribute('href').slice(1)
     const $anchor = document.getElementById(id);
-    const offsetTop = $anchor.getBoundingClientRect().top + window.pageYOffset;
-    window.scroll({
-      top: offsetTop - offset(),
-      behavior: 'smooth'
-    })
+
+    if ($anchor) {
+      const offsetTop = $anchor.getBoundingClientRect().top + window.pageYOffset;
+      window.scroll({
+        top: offsetTop - offset(),
+        behavior: 'smooth'
+      })
+    }
+
     if (this.props.onClick) {this.props.onClick(e)}
   }
   render() {


### PR DESCRIPTION
We have some dynamic sections where it's possible you could get in a state that an ID isn't present on the page but an onClick handler is still invoked. In general, I think this will help the codepath silently fail (maybe add a console warning?) and prevent an undefined reference on a missing ID. 